### PR TITLE
fix: Update sidebar menu link and adjust input field attributes

### DIFF
--- a/Modules/ITSM/Resources/views/layouts/partials/sidebar/menu.blade.php
+++ b/Modules/ITSM/Resources/views/layouts/partials/sidebar/menu.blade.php
@@ -47,8 +47,8 @@
         <!--begin:Menu item-->
         <div class="menu-item">
             <!--begin:Menu link-->
-            <a class="menu-link {{ request()->routeIs('itsm.logbooks') ? 'active' : '' }}"
-                href="{{ route('itsm.logbooks') }}">
+            <a class="menu-link {{ request()->routeIs('itsm.logbook') ? 'active' : '' }}"
+                href="{{ route('itsm.logbook') }}">
                 <span class="menu-bullet">
                     <span class="bullet bullet-dot"></span>
                 </span>

--- a/resources/_keenthemes/src/js/custom/apps/itsm/incident.js
+++ b/resources/_keenthemes/src/js/custom/apps/itsm/incident.js
@@ -840,7 +840,8 @@ var KTIncident = function () {
 
                         // Find the input element by its id
                         var incidentInput = document.getElementById('incident');
-                        incidentInput.setAttribute('readonly', false); // User Requested
+                        incidentInput.removeAttribute('readonly');
+                        // incidentInput.setAttribute('readonly', false); // User Requested
 
                         // Create a new hidden input element
                         var hiddenInput = document.createElement("input");

--- a/resources/_keenthemes/src/js/custom/apps/itsm/service.js
+++ b/resources/_keenthemes/src/js/custom/apps/itsm/service.js
@@ -828,7 +828,8 @@ var KTService = function () {
 
                         // Find the input element by its id
                         var serviceInput = document.getElementById('service');
-                        serviceInput.setAttribute('readonly', false); // User Requested
+                        serviceInput.removeAttribute('readonly');
+                        // serviceInput.setAttribute('readonly', false); // User Requested
 
                         // Create a new hidden input element
                         var hiddenInput = document.createElement("input");


### PR DESCRIPTION
- Correct the route reference for the logbook menu item in the sidebar.
- Modify incident and service JavaScript files to remove the readonly attribute from input fields, enhancing user interaction.